### PR TITLE
Fix typo in `index.rst`

### DIFF
--- a/.github/workflows/rtd-link-preview.yml
+++ b/.github/workflows/rtd-link-preview.yml
@@ -13,4 +13,4 @@ jobs:
     steps:
       - uses: readthedocs/actions/preview@v1
         with:
-          project-slug: "cge_modeling"
+          project-slug: "cge-modeling"

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,11 +9,11 @@ Quick Setup
 Citation
 ========
 
-If you use gEconpy in your research, please cite the package using the following BibTeX entry:
+If you use cge_modeling in your research, please cite the package using the following BibTeX entry:
 
 .. code-block:: bibtex
 
-   @software{gEconpy,
+   @software{cge_modeling,
      author = {Jesse Grabowski},
      title = {cge_modeling: Computable General Equlibirum Models in Python},
      url = {https://github.com/jessegrabowski/cge_modeling},


### PR DESCRIPTION
I didn't change the package name when I copied the docs from gEconpy!

<!-- readthedocs-preview cge_modeling start -->
----
📚 Documentation preview 📚: https://cge_modeling--19.org.readthedocs.build/en/19/

<!-- readthedocs-preview cge_modeling end -->