### PR TITLE
Return a single ragged list from `f_step` in JAX mode

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -11,13 +11,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.11", "3.12"]
-        environment_file: ["cge_test", "cge_test_windows"]
-        exclude:
+        include:
           - os: ubuntu-latest
             python-version: "3.12"
             environment_file: cge_test
-
           - os: windows-latest
             python-version: "3.11"
             environment_file: cge_test_windows

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -15,8 +15,10 @@ jobs:
         exclude:
           - os: ubuntu-latest
             python-version: "3.12"
+            environment_file: cge_test
           - os: windows-latest
             python-version: "3.11"
+            environment_file: cge_test_windows
         test-subset:
           - |
             tests/
@@ -59,7 +61,7 @@ jobs:
         mamba-version: "*"
         activate-environment: cge-test
         channel-priority: strict
-        environment-file: conda_envs/cge_test.yml
+        environment-file: conda_envs/${{ matrix.environment_file }}.yml
         python-version: ${{matrix.python-version}}
         use-mamba: true
         use-only-tar-bz2: false # IMPORTANT: This may break caching of conda packages! See https://github.com/conda-incubator/setup-miniconda/issues/267

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -12,10 +12,12 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         python-version: ["3.11", "3.12"]
+        environment_file: ["cge_test", "cge_test_windows"]
         exclude:
           - os: ubuntu-latest
             python-version: "3.12"
             environment_file: cge_test
+
           - os: windows-latest
             python-version: "3.11"
             environment_file: cge_test_windows

--- a/cge_modeling/__init__.py
+++ b/cge_modeling/__init__.py
@@ -4,6 +4,16 @@ from cge_modeling.plotting import plot_kateplot, plot_lines
 from cge_modeling.pytensorf.rewrites import prod_to_no_zero_prod  # noqa: F401
 from cge_modeling.tools.output_tools import display_info_as_table, latex_print_equations
 
+import logging
+
+_log = logging.getLogger("cge_modeling")
+if not logging.root.handlers:
+    _log.setLevel(logging.INFO)
+    if len(_log.handlers) == 0:
+        handler = logging.StreamHandler()
+        _log.addHandler(handler)
+
+
 __version__ = "0.0.1"
 
 __all__ = [

--- a/cge_modeling/__init__.py
+++ b/cge_modeling/__init__.py
@@ -1,10 +1,10 @@
+import logging
+
 from cge_modeling.base.cge import CGEModel
 from cge_modeling.base.primitives import Equation, Parameter, Variable
 from cge_modeling.plotting import plot_kateplot, plot_lines
 from cge_modeling.pytensorf.rewrites import prod_to_no_zero_prod  # noqa: F401
 from cge_modeling.tools.output_tools import display_info_as_table, latex_print_equations
-
-import logging
 
 _log = logging.getLogger("cge_modeling")
 if not logging.root.handlers:

--- a/cge_modeling/base/cge.py
+++ b/cge_modeling/base/cge.py
@@ -765,7 +765,9 @@ class CGEModel:
             f_resid, f_grad, f_hess, f_hessp = None, None, None, None
 
             if mode == "JAX":
-                f_resid, f_grad, f_hessp = jax_loss_grad_hessp(system, variables, parameters)
+                f_resid, f_grad, f_hess, f_hessp = jax_loss_grad_hessp(
+                    system, variables, parameters
+                )
             else:
                 _log.info("Computing sum of squared errors")
                 resid = (system**2).mean()

--- a/cge_modeling/pytensorf/rewrites.py
+++ b/cge_modeling/pytensorf/rewrites.py
@@ -13,7 +13,6 @@ def prod_to_no_zero_prod(fgraph, node):
     Note that this only affects product reduction Ops, it's not the same as a multiplication.
     """
     if isinstance(node.op, Prod) and not node.op.no_zeros_in_input:
-        print("hi :)")
         (x,) = node.inputs
         new_op = Prod(dtype=node.op.dtype, acc_dtype=node.op.dtype, no_zeros_in_input=True)
         return [new_op(x)]

--- a/conda_envs/cge_test_windows.yml
+++ b/conda_envs/cge_test_windows.yml
@@ -12,7 +12,6 @@ dependencies:
   - IPython
   - pymc
   - pytensor
-  - jax
   - tqdm
   - numba-progress
   - fastprogress

--- a/tests/test_cge_model.py
+++ b/tests/test_cge_model.py
@@ -424,16 +424,20 @@ def test_pytensor_from_sympy(model_function, calibrate_model, f_expected_jac, da
     ],
     ids=["minimize", "root", "euler"],
 )
+@pytest.mark.parametrize("mode", ["FAST_RUN", "JAX"], ids=["FAST_RUN", "JAX"])
 def test_backends_agree(
     model_function: Callable,
     calibrate_model: Callable,
     data: dict,
     method: str,
     solver_kwargs: dict,
+    mode: str,
 ):
+    if mode in ["JAX"]:
+        pytest.importorskip(mode.lower())
     model_numba = model_function(backend="numba")
     model_pytensor = model_function(
-        backend="pytensor", mode="FAST_COMPILE", parse_equations_to_sympy=False
+        backend="pytensor", mode=mode, parse_equations_to_sympy=False
     )
 
     def solver_agreement_checks(results: list, names: list):

--- a/tests/test_cge_model.py
+++ b/tests/test_cge_model.py
@@ -436,9 +436,7 @@ def test_backends_agree(
     if mode in ["JAX"]:
         pytest.importorskip(mode.lower())
     model_numba = model_function(backend="numba")
-    model_pytensor = model_function(
-        backend="pytensor", mode=mode, parse_equations_to_sympy=False
-    )
+    model_pytensor = model_function(backend="pytensor", mode=mode, parse_equations_to_sympy=False)
 
     def solver_agreement_checks(results: list, names: list):
         for res, name in zip(results, names):


### PR DESCRIPTION
`simulate` was failing when `mode="JAX"` because the `f_step` function was returning two ragged lists instead of just one.

Also adds tests for simulate in JAX mode

<!-- readthedocs-preview cge-modeling start -->
----
📚 Documentation preview 📚: https://cge-modeling--22.org.readthedocs.build/en/22/

<!-- readthedocs-preview cge-modeling end -->