### PR TITLE
Jax euler inverse

### DIFF
--- a/cge_modeling/base/cge.py
+++ b/cge_modeling/base/cge.py
@@ -891,13 +891,6 @@ class CGEModel:
                         current_variable_vals = current_step[: len(self.variable_names)]
                         current_parameter_vals = current_step[len(self.variable_names) :]
 
-                        # current_variable_vals = flat_current_step[
-                        #     : len(self.variable_names)
-                        # ]
-                        # current_parameter_vals = flat_current_step[
-                        #     len(self.variable_names) :
-                        # ]
-
                         current_variables = {
                             k: current_variable_vals[i] for i, k in enumerate(self.variable_names)
                         }

--- a/cge_modeling/pytensorf/compile.py
+++ b/cge_modeling/pytensorf/compile.py
@@ -472,10 +472,8 @@ def jax_euler_step(system, variables, parameters):
         step_size = (theta_final_vec - theta0_vec) / n_steps
 
         A = jax.jacobian(f_sys, 0)(x_vec, theta_vec)
-        A_inv = jax.scipy.linalg.solve(A, jnp.eye(A.shape[0]))
-
         _, Bv = jax.jvp(lambda theta: f_sys(x_vec, theta), (theta_vec,), (step_size,))
-        step = -A_inv @ Bv
+        step = -jax.scipy.linalg.solve(A, Bv)
 
         x_next_vec = x_vec + step
         theta_next_vec = theta_vec + step_size

--- a/tests/test_pytensorf.py
+++ b/tests/test_pytensorf.py
@@ -13,10 +13,9 @@ def test_euler_approximation_1d():
     n_steps = pt.iscalar("n_steps")
 
     A = make_jacobian(eq, [y])
-    A_inv = 1 / A
     B = make_jacobian(eq, [x])
 
-    x0_final, result = euler_approximation(A_inv, B, variables=[y], parameters=[x], n_steps=n_steps)
+    x0_final, result = euler_approximation(A, B, variables=[y], parameters=[x], n_steps=n_steps)
     f = pytensor.function([x, y, x0_final, n_steps], result)
     y_values, x_values = f(0, 0, np.array([10.0]), 10_000)
     true = -np.cos(np.array([10])) + 1


### PR DESCRIPTION
I was previously doing `step = int(A) @ Bv`, which is very silly. This patch does `step = solve(A, Bv)` instead.

<!-- readthedocs-preview cge-modeling start -->
----
📚 Documentation preview 📚: https://cge-modeling--24.org.readthedocs.build/en/24/

<!-- readthedocs-preview cge-modeling end -->