### PR TITLE
Remove deprecated `inverse_method` option

### DIFF
--- a/cge_modeling/__init__.py
+++ b/cge_modeling/__init__.py
@@ -14,7 +14,7 @@ if not logging.root.handlers:
         _log.addHandler(handler)
 
 
-__version__ = "0.0.2"
+__version__ = "0.0.3"
 
 __all__ = [
     "CGEModel",

--- a/cge_modeling/base/cge.py
+++ b/cge_modeling/base/cge.py
@@ -103,7 +103,6 @@ class CGEModel:
         apply_sympy_simplify: bool = False,
         backend: Literal["pytensor", "numba"] | None = "pytensor",
         mode: str | None = None,
-        inverse_method: str = "solve",
         use_sparse_matrices: bool = False,
         compile: list[CompiledFunctions] | None = "all",
         use_scan_euler: bool = False,
@@ -148,10 +147,6 @@ class CGEModel:
         mode: str, optional
             Compilation mode for the pytensor backend. One of None, "JAX", or "NUMBA". Defaults to None. Note that this
             argument is ignored if the backend is not "pytensor".
-
-        inverse_method: str, optional
-            Method to use to compute the inverse of the Jacobian matrix. One of "solve", "pinv", or "SGD".
-            Defaults to "solve". Ignored if the backend is not "pytensor".
 
         use_sparse_matrices: bool, optional
             Whether to use sparse matrices to represent matrices associated with the system (e.g. the Jacobian matrix).

--- a/cge_modeling/pytensorf/compile.py
+++ b/cge_modeling/pytensorf/compile.py
@@ -359,7 +359,7 @@ def pytensor_euler_step(system, A, B, variables, parameters):
         v = flatten_equations(step_size)
         Bv = B @ v
 
-    step = pt.linalg.solve(-A, Bv)
+    step = -pt.linalg.solve(A, Bv)
     step.name = "euler_step"
 
     delta_x = flat_tensor_to_ragged_list(step, x_shapes)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = cge_modeling
-version = 0.0.2
+version = 0.0.3
 description = A package for working with computable general equilibrium (CGE) models
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
Bump version

<!-- readthedocs-preview cge-modeling start -->
----
📚 Documentation preview 📚: https://cge-modeling--25.org.readthedocs.build/en/25/

<!-- readthedocs-preview cge-modeling end -->