### PR TITLE
Add option for RK4 in Euler approximation

### DIFF
--- a/cge_modeling/base/build.py
+++ b/cge_modeling/base/build.py
@@ -1,5 +1,6 @@
 import importlib.util
 
+from functools import partial
 from typing import Literal, cast
 
 from pytensor.compile import get_mode
@@ -52,6 +53,7 @@ def compile_model(
     use_sparse_matrices: bool = False,
     functions_to_compile: list[CompiledFunctions] | tuple[CompiledFunctions] | None = "all",
     use_scan_euler: bool = False,
+    use_rk4: bool = False,
 ) -> CGEModel:
     if (
         backend == "pytensor"
@@ -61,9 +63,9 @@ def compile_model(
     ):
         from cge_modeling.compile.jax import compile_jax_cge_functions
 
-        func_maker = compile_jax_cge_functions
+        func_maker = partial(compile_jax_cge_functions, use_rk4=use_rk4)
     else:
-        func_maker = COMPILE_FUNC_FACTORY[backend]
+        func_maker = partial(COMPILE_FUNC_FACTORY[backend], use_rk4=use_rk4)
 
     functions_to_compile = _parse_compile_kwarg(functions_to_compile)
 
@@ -105,6 +107,7 @@ def cge_model(
     use_sparse_matrices: bool = False,
     functions_to_compile: list[CompiledFunctions] | tuple[CompiledFunctions] | None = "all",
     use_scan_euler: bool = False,
+    use_rk4_euler: bool = False,
 ) -> CGEModel:
     if backend is None:
         backend = determine_default_backend(equations)
@@ -125,4 +128,5 @@ def cge_model(
         use_sparse_matrices=use_sparse_matrices,
         functions_to_compile=functions_to_compile,
         use_scan_euler=use_scan_euler,
+        use_rk4=use_rk4_euler,
     )

--- a/cge_modeling/compile/euler.py
+++ b/cge_modeling/compile/euler.py
@@ -83,6 +83,7 @@ def symbolic_euler_approximation(
     parameters: list[pt.Variable],
     jacobian: pt.TensorVariable | None = None,
     grad: pt.TensorVariable | None = None,
+    use_rk4: bool = False,
 ) -> tuple[pt.TensorVariable, pt.TensorVariable, list[pt.TensorVariable]]:
     """
     Find the solution to a system of equations using the Euler approximation method.
@@ -126,14 +127,17 @@ def symbolic_euler_approximation(
     theta_list = cast(list, at_least_list(parameters))
 
     theta_initial = [clone_and_rename(x, suffix="_initial") for x in theta_list]
-    theta_final = [clone_and_rename(x, suffix="_final") for x in theta_list]
+    # theta_final = [clone_and_rename(x, suffix="_final") for x in theta_list]
+    # theta_final_vec = pt.concatenate([pt.atleast_1d(x).flatten() for x in theta_final], axis=-1)
 
-    theta_final_vec = pt.concatenate([pt.atleast_1d(x).flatten() for x in theta_final], axis=-1)
     theta_initial_vec = pt.concatenate([pt.atleast_1d(x).flatten() for x in theta_initial], axis=-1)
+    theta_final = pt.tensor(
+        name="theta_final", shape=theta_initial_vec.type.shape, dtype=theta_initial_vec.type.dtype
+    )
 
     n_steps = pt.scalar("n_steps", dtype="int32")
 
-    step_size = (theta_final_vec - theta_initial_vec) / n_steps
+    step_size = (theta_final - theta_initial_vec) / n_steps
 
     Bv = B @ pt.atleast_1d(step_size)
     Bv.name = "Bv"
@@ -142,7 +146,7 @@ def symbolic_euler_approximation(
     rewrite_pregrad(step)
 
     f_step = OpFromGraph(
-        inputs=x_list + theta_list + theta_initial + theta_final + [n_steps],
+        inputs=x_list + theta_list + theta_initial + [theta_final, n_steps],
         outputs=[step, step_size],
         inline=True,
     )
@@ -156,14 +160,53 @@ def symbolic_euler_approximation(
         x_prev = args[:x_args]
         theta_prev = args[x_args : x_args + theta_args]
         theta_initial = args[x_args + theta_args : x_args + 2 * theta_args]
-        theta_final = args[x_args + 2 * theta_args : -1]
+        # theta_final = args[x_args + 2 * theta_args : -1]
+        theta_final = args[-2]
         n_steps = args[-1]
 
-        step, step_size = f_step(*x_prev, *theta_prev, *theta_initial, *theta_final, n_steps)
-        delta_x = flat_tensor_to_ragged_list(step, x_shapes)
-        x_next = [x + dx for x, dx in zip(x_prev, delta_x)]
+        if use_rk4:
+            dx1, step_size = f_step(*x_prev, *theta_prev, *theta_initial, theta_final, n_steps)
+            delta_x1 = flat_tensor_to_ragged_list(dx1, x_shapes)
+            delta_theta = flat_tensor_to_ragged_list(step_size, theta_shapes)
 
-        delta_theta = flat_tensor_to_ragged_list(step_size, theta_shapes)
+            dx2, _ = f_step(
+                *[x + 0.5 * dx for x, dx in zip(x_prev, delta_x1)],
+                *[theta + 0.5 * d_theta for theta, d_theta in zip(theta_prev, delta_theta)],
+                *theta_initial,
+                theta_final,
+                n_steps,
+            )
+            delta_x2 = flat_tensor_to_ragged_list(dx2, x_shapes)
+
+            dx3, _ = f_step(
+                *[x + 0.5 * dx for x, dx in zip(x_prev, delta_x2)],
+                *[theta + 0.5 * d_theta for theta, d_theta in zip(theta_prev, delta_theta)],
+                *theta_initial,
+                theta_final,
+                n_steps,
+            )
+            delta_x3 = flat_tensor_to_ragged_list(dx3, x_shapes)
+
+            dx4, _ = f_step(
+                *[x + dx for x, dx in zip(x_prev, delta_x3)],
+                *[theta + d_theta for theta, d_theta in zip(theta_prev, delta_theta)],
+                *theta_initial,
+                theta_final,
+                n_steps,
+            )
+            delta_x4 = flat_tensor_to_ragged_list(dx4, x_shapes)
+
+            delta_x = [
+                (dx1 + 2 * dx2 + 2 * dx3 + dx4) / 6
+                for dx1, dx2, dx3, dx4 in zip(delta_x1, delta_x2, delta_x3, delta_x4)
+            ]
+
+        else:
+            step, step_size = f_step(*x_prev, *theta_prev, *theta_initial, theta_final, n_steps)
+            delta_x = flat_tensor_to_ragged_list(step, x_shapes)
+            delta_theta = flat_tensor_to_ragged_list(step_size, theta_shapes)
+
+        x_next = [x + dx for x, dx in zip(x_prev, delta_x)]
         theta_next = [theta + dtheta for theta, dtheta in zip(theta_prev, delta_theta)]
 
         assert len(theta_next) == len(theta_prev)
@@ -172,7 +215,7 @@ def symbolic_euler_approximation(
     result, updates = pytensor.scan(
         step_func,
         outputs_info=x_list + theta_list,
-        non_sequences=theta_list + theta_final + [n_steps],
+        non_sequences=[*theta_list, theta_final, n_steps],
         n_steps=n_steps,
         strict=True,
     )

--- a/cge_modeling/compile/euler.py
+++ b/cge_modeling/compile/euler.py
@@ -82,7 +82,6 @@ def symbolic_euler_approximation(
     variables: list[pt.Variable],
     parameters: list[pt.Variable],
     jacobian: pt.TensorVariable | None = None,
-    grad: pt.TensorVariable | None = None,
     use_rk4: bool = False,
 ) -> tuple[pt.TensorVariable, pt.TensorVariable, list[pt.TensorVariable]]:
     """
@@ -105,8 +104,6 @@ def symbolic_euler_approximation(
     jacobian: TensorVariable, optional
         A matrix of partial derivatives df(x) / dx. If not provided, it will be computed from the the system and
         variables.
-    n_steps: int
-        The number of steps to take in the Euler approximation
 
     Returns
     -------
@@ -127,9 +124,6 @@ def symbolic_euler_approximation(
     theta_list = cast(list, at_least_list(parameters))
 
     theta_initial = [clone_and_rename(x, suffix="_initial") for x in theta_list]
-    # theta_final = [clone_and_rename(x, suffix="_final") for x in theta_list]
-    # theta_final_vec = pt.concatenate([pt.atleast_1d(x).flatten() for x in theta_final], axis=-1)
-
     theta_initial_vec = pt.concatenate([pt.atleast_1d(x).flatten() for x in theta_initial], axis=-1)
     theta_final = pt.tensor(
         name="theta_final", shape=theta_initial_vec.type.shape, dtype=theta_initial_vec.type.dtype
@@ -160,7 +154,6 @@ def symbolic_euler_approximation(
         x_prev = args[:x_args]
         theta_prev = args[x_args : x_args + theta_args]
         theta_initial = args[x_args + theta_args : x_args + 2 * theta_args]
-        # theta_final = args[x_args + 2 * theta_args : -1]
         theta_final = args[-2]
         n_steps = args[-1]
 

--- a/cge_modeling/compile/numba.py
+++ b/cge_modeling/compile/numba.py
@@ -129,7 +129,9 @@ def euler_approx(f_step, *, x0, theta0, theta_final, n_steps, progress_bar):
     return output
 
 
-def compile_numba_euler_func(variables, parameters, equations, jacobian=None):
+def compile_numba_euler_func(variables, parameters, equations, jacobian=None, use_rk4=False):
+    if use_rk4:
+        raise NotImplementedError("RK4 not yet implemented for Numba")
     if jacobian is None:
         A_mat = make_sympy_jacobian(equations, variables)
     else:

--- a/cge_modeling/compile/sympytensor.py
+++ b/cge_modeling/compile/sympytensor.py
@@ -308,8 +308,9 @@ def compile_sympytensor_cge_functions(
     cge_model: CGEModel,
     functions_to_compile: list[CompiledFunctions],
     mode: str | None = None,
-    use_scan_for_euler: bool = False,
+    use_scan_euler: bool = False,
     use_sparse_matrices: bool = False,
+    use_rk4: bool = False,
     *args,
     **kwargs,
 ) -> tuple[Function | None, ...]:
@@ -400,9 +401,9 @@ def compile_sympytensor_cge_functions(
         )
 
     if "euler" in functions_to_compile:
-        if not use_scan_for_euler:
+        if not use_scan_euler:
             inputs, outputs = pytensor_euler_step(
-                system, variables, parameters, jacobian=None, grad=None
+                system, variables, parameters, jacobian=None, grad=None, use_rk4=use_rk4
             )
 
             f_step = pytensor.function(inputs, outputs, mode=mode, trust_input=True)

--- a/conda_envs/cge_test.yml
+++ b/conda_envs/cge_test.yml
@@ -3,10 +3,9 @@ channels:
 - conda-forge
 dependencies:
   # Base dependencies
-  - pip
   - numpy
   - scipy
-  - sympy>1.13.2
+  - sympy>=1.14.0
   - pandas
   - numba
   - pymc
@@ -17,14 +16,15 @@ dependencies:
   - joblib
   - cvxpy
   - better-optimize>=0.1.2
-  - sympytensor>=1.3.2
+  - sympytensor>=1.3.3
   - IPython
 
+  - pip
   - pip:
     - latextable
     - texttable
     - squarify
-    - jax
+    - jax # Needs to be pip installed for the windows CI runner
 
   # Testing dependencies
   - pre-commit

--- a/conda_envs/environment.yml
+++ b/conda_envs/environment.yml
@@ -7,21 +7,21 @@ dependencies:
   - pip
   - numpy
   - scipy
-  - sympy<1.13
+  - sympy>=1.14.0
   - pandas
   - numba
   - pytensor
   - tqdm
   - numba-progress
-  - fastprogress
   - matplotlib
   - jax
   - joblib
   - cvxpy
 
+  - sympytensor>=1.3.3
+  - better-optimize>=0.1.2
+
   - pip:
       - texttable
       - latextable
       - squarify
-      - sympytensor
-      - better_optimize

--- a/conda_envs/environment_dev.yml
+++ b/conda_envs/environment_dev.yml
@@ -4,11 +4,9 @@ channels:
 dependencies:
   # Base dependencies
   - python=3.12
-  - jupyter
-  - pip
   - numpy
   - scipy
-  - sympy<1.13
+  - sympy>=1.14.0
   - pandas
   - numba
   - IPython
@@ -16,25 +14,22 @@ dependencies:
   - pytensor
   - tqdm
   - numba-progress
-  - fastprogress
   - matplotlib
   - joblib
   - cvxpy
+  - sympytensor>=1.3.3
+  - better-optimize>=0.1.2
 
   # JAX Backend
   - jax
   - numpyro
   - blackjax
 
+  - pip
   - pip:
       - texttable
       - latextable
       - squarify
-      - jupyter_contrib_nbextensions
-      - jupyter_nbextensions_configurator
-      - sympytensor
-      - better_optimize
-
 
   # For building docs
   - ipython

--- a/conda_envs/environment_docs.yml
+++ b/conda_envs/environment_docs.yml
@@ -6,7 +6,7 @@ dependencies:
   - pip
   - numpy
   - scipy
-  - sympy<1.13
+  - sympy>=1.14.0
   - pandas
   - numba
   - IPython
@@ -14,17 +14,17 @@ dependencies:
   - pytensor
   - tqdm
   - numba-progress
-  - fastprogress
   - matplotlib
   - joblib
   - cvxpy
 
+  - sympytensor>=1.3.3
+  - better-optimize>=0.1.2
+
   - pip:
     - latextable
     - texttable
-    - sympytensor
     - squarify
-    - better_optimize
 
   # Extra dependencies for docs build
   - ipython

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,14 +39,14 @@ dependencies = [
     "setuptools",
     "numba",
     "numpy",
-    "sympy>1.13.2",
+    "sympy>=1.14.0",
     "scipy",
     "pandas",
     "joblib",
     "pytensor",
     "latextable",
     "texttable",
-    "sympytensor>=1.3.2",
+    "sympytensor>=1.3.3",
     "xarray",
     "arviz",
     "numba-progress",
@@ -60,7 +60,6 @@ dev = [
     "pre-commit",
     "pytest",
     "pytest-cov",
-    "versioneer"
 ]
 
 docs = [
@@ -153,15 +152,15 @@ lines-between-types = 1
 
 [tool.ruff.lint.per-file-ignores]
 'tests/*.py' = [
-  'F841', # Unused variable warning for test files -- common in pymc model declarations
-  'D106',  # Missing docstring for public method -- unittest test subclasses don't need docstrings
-  'F401', # Unused import warning for test files -- this check removes imports of fixtures
-  'F811',  # Redefine while unused -- this check fails on imported fixtures
+    'F841', # Unused variable warning for test files -- common in pymc model declarations
+    'D106',  # Missing docstring for public method -- unittest test subclasses don't need docstrings
+    'F401', # Unused import warning for test files -- this check removes imports of fixtures
+    'F811',  # Redefine while unused -- this check fails on imported fixtures
 ]
 'cge_modeling/compile/numba_tools.py' = [
-      'F401', # Unused import warning -- imports are used in generated code strings
+    'F401', # Unused import warning -- imports are used in generated code strings
 ]
 'cge_modeling/__init__.py' = [
-        'F401', # Unused import warning -- need to import (but not use) pytensor rewrite
-        'I001' # Import order matters to avoid circular imports
+    'F401', # Unused import warning -- need to import (but not use) pytensor rewrite
+    'I001' # Import order matters to avoid circular imports
 ]

--- a/tests/compile/test_euler.py
+++ b/tests/compile/test_euler.py
@@ -1,12 +1,13 @@
 import numpy as np
 import pytensor
-
-from pytensor import tensor as pt
+import pytensor.tensor as pt
+import pytest
 
 from cge_modeling.compile.euler import symbolic_euler_approximation
 
 
-def test_compile_euler_approximation_function():
+@pytest.mark.parametrize("use_rk4", [True, False])
+def test_compile_euler_approximation_function(use_rk4):
     # Example problem from Notes and Problems from Applied General Equilibrium Economics, Chapter 3
 
     variables = v1, v2 = [pt.dscalar(name) for name in ["v1", "v2"]]
@@ -21,7 +22,7 @@ def test_compile_euler_approximation_function():
     mode = "FAST_RUN"
 
     theta_final, n_steps, result = symbolic_euler_approximation(
-        equations, variables=variables, parameters=[parameters]
+        equations, variables=variables, parameters=[parameters], use_rk4=use_rk4
     )
     f = pytensor.function([*variables, parameters, theta_final, n_steps], result, mode=mode)
 
@@ -31,7 +32,9 @@ def test_compile_euler_approximation_function():
     v3_final = 2
 
     analytic_solution = f_analytic(v3_final)
-    approximate_solutions = [np.c_[f(*initial_point, v3_initial, v3_final, n)[:2]].T for n in steps]
+    approximate_solutions = [
+        np.c_[f(*initial_point, v3_initial, [v3_final], n)[:2]].T for n in steps
+    ]
     errors = np.c_[[solution[-1] - analytic_solution for solution in approximate_solutions]]
 
     # Test the errors are monotonically decreasing in the number of steps
@@ -48,7 +51,7 @@ def test_euler_approximation_1d():
 
     x0_final, n_steps, result = symbolic_euler_approximation(eq, variables=[y], parameters=[x])
     f = pytensor.function([x, y, x0_final, n_steps], result)
-    y_values, x_values = f(0, 0, 10.0, 10_000)
+    y_values, x_values = f(0, 0, [10.0], 10_000)
     true = -np.cos(np.array([10])) + 1
     np.testing.assert_allclose(-true, y_values[-1], atol=1e-3)
 
@@ -73,7 +76,7 @@ def test_euler_approximation_2d():
 
     initial_point = [1.0, 1.0]
     v3_initial = 1.0
-    v3_final = 2.0
+    v3_final = [2.0]
 
     analytic_solution = np.array(f_analytic(v3_final))
     *x, theta = f(*initial_point, v3_initial, v3_final, 10_000)


### PR DESCRIPTION
RK4 is a method for improving accuracy of linear approximations of ODEs. When we do Euler approximation, we're essentially solving an implicit ODE. Using RK4 is more expensive, but greatly reduces the linear approximation error as step size grows,  allowing for larger step size. I have found the trade-off to be beneficial on expensive models.

<!-- readthedocs-preview cge-modeling start -->
----
📚 Documentation preview 📚: https://cge-modeling--54.org.readthedocs.build/en/54/

<!-- readthedocs-preview cge-modeling end -->